### PR TITLE
Feat: RSS-PZ-07 add start button start page

### DIFF
--- a/rss-puzzle/src/app/app.ts
+++ b/rss-puzzle/src/app/app.ts
@@ -1,13 +1,21 @@
 import createElement from 'helpers/createElement';
-import { Login } from 'types/interfaces';
+import { Login, BaseClass } from 'types/interfaces';
 import { initialState } from 'state/initialState';
 import LoginPage from './pages/login/login';
+import StartPage from './pages/startPage/startPage';
+import MainPage from './pages/mainPage/mainPage';
 
 class App {
   login: Login;
 
+  startPage: BaseClass;
+
+  mainPage: BaseClass;
+
   constructor() {
     this.login = new LoginPage();
+    this.startPage = new StartPage(this.changePage);
+    this.mainPage = new MainPage();
   }
 
   public start(): void {
@@ -22,5 +30,13 @@ class App {
 
     this.login.draw(root);
   }
+
+  changePage = (): void => {
+    const root = document.getElementById('root');
+    if (root instanceof HTMLElement) {
+      root.innerHTML = '';
+      this.mainPage.draw(root);
+    }
+  };
 }
 export default App;

--- a/rss-puzzle/src/app/pages/login/loginForm/loginForm.scss
+++ b/rss-puzzle/src/app/pages/login/loginForm/loginForm.scss
@@ -67,33 +67,6 @@ $error-color: rgb(255, 0, 0);
     font-size: 14px;
     text-transform: none;
   }
-
-  .login-button {
-    height: 50px;
-    @include radius-padding(10px, 10px);
-    border: none;
-    @include transition;
-    font-size: 18px;
-    letter-spacing: 5px;
-    color: $dark-grey;
-    @include text-transform(uppercase);
-
-    &:hover {
-      cursor: pointer;
-      color: $text-color;
-      background-color: $main-green;
-      box-shadow: 0px 10px 20px rgba(46, 229, 157, 0.4);
-      @include transition;
-    }
-
-    &:disabled {
-      cursor: default;
-      color: inherit;
-      background: #f0f0f0;
-      box-shadow: none;
-      opacity: 0.5;
-    }
-  }
 }
 
 @media (max-width: 450px) {

--- a/rss-puzzle/src/app/pages/login/loginForm/loginForm.ts
+++ b/rss-puzzle/src/app/pages/login/loginForm/loginForm.ts
@@ -1,6 +1,7 @@
 import createElement from 'helpers/createElement';
 import { LoginFormType, InputClassType } from 'types/interfaces';
 import { saveUserData } from 'helpers/saveUserData';
+import CustomButton from 'components/customButton/customButton';
 import InputClass from '../inputClass/inputClass';
 import './loginForm.scss';
 
@@ -20,14 +21,18 @@ class LoginForm implements LoginFormType {
     const form = createElement('form', { name: 'login', class: 'login-form' });
     const inputTags = this.input.draw();
 
-    const loginButton = createElement('input', {
-      class: 'login-button',
-      type: 'submit',
-      value: 'Login',
-      disabled: 'disabled',
+    const button = new CustomButton({
+      element: 'button',
+      attributes: {
+        class: 'button login-button',
+        type: 'submit',
+        value: 'Login',
+        disabled: 'disabled',
+      },
+      textContent: 'Login',
     });
 
-    [loginButton, ...inputTags].forEach((element) => form.prepend(element));
+    [button.render(), ...inputTags].forEach((element) => form.prepend(element));
 
     form.addEventListener('submit', this.callback.bind(this));
 

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.scss
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.scss
@@ -1,0 +1,14 @@
+@mixin flex {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.main-page {
+  width: 100vw;
+  height: 100vh;
+  @include flex;
+  background: #444;
+  color: #fff;
+}

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.ts
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.ts
@@ -1,0 +1,11 @@
+import createElement from 'helpers/createElement';
+import './mainPage.scss';
+
+class MainPage {
+  draw(root: HTMLElement): void {
+    const startPage = createElement('div', { class: 'main-page' }, 'Main Page');
+    root.append(startPage);
+  }
+}
+
+export default MainPage;

--- a/rss-puzzle/src/app/pages/startPage/startPage.ts
+++ b/rss-puzzle/src/app/pages/startPage/startPage.ts
@@ -14,10 +14,13 @@ class StartPage {
 
   contentBlocks: string[];
 
-  constructor() {
+  callback: () => void;
+
+  constructor(callback: () => void) {
     this.content = new GameInfo();
     this.userGreeting = new UserInfo();
     this.contentBlocks = ['start', 'user'];
+    this.callback = callback;
   }
 
   draw(root: HTMLElement): void {
@@ -38,7 +41,7 @@ class StartPage {
         attributes: { class: 'button start-btn' },
         textContent: 'Start',
       },
-      this.playApp
+      this.playApp.bind(this)
     );
 
     startPage.append(button.render());
@@ -50,6 +53,8 @@ class StartPage {
       'rss-puzzle-login',
       JSON.stringify({ ...initialState, currentPage: 'main' })
     );
+    initialState.updatePage('main');
+    this.callback();
   }
 }
 

--- a/rss-puzzle/src/app/pages/startPage/startPage.ts
+++ b/rss-puzzle/src/app/pages/startPage/startPage.ts
@@ -1,5 +1,7 @@
 import createElement from 'helpers/createElement';
 import { BaseClass } from 'types/interfaces';
+import { initialState } from 'state/initialState';
+import CustomButton from 'components/customButton/customButton';
 import GameInfo from './gameInfo/gameInfo';
 import UserInfo from './userInfo/userInfo';
 
@@ -30,7 +32,24 @@ class StartPage {
       startPage.append(container);
     });
 
+    const button = new CustomButton(
+      {
+        element: 'button',
+        attributes: { class: 'button start-btn' },
+        textContent: 'Start',
+      },
+      this.playApp
+    );
+
+    startPage.append(button.render());
     root.append(startPage);
+  }
+
+  private playApp(): void {
+    localStorage.setItem(
+      'rss-puzzle-login',
+      JSON.stringify({ ...initialState, currentPage: 'main' })
+    );
   }
 }
 

--- a/rss-puzzle/src/components/customButton/customButton.scss
+++ b/rss-puzzle/src/components/customButton/customButton.scss
@@ -1,0 +1,47 @@
+$text-color: #fff;
+$dark-grey: #444;
+$main-green: #2ee59d;
+
+@mixin transition {
+  transition: 0.5s ease-in;
+}
+
+@mixin text-transform($transform) {
+  text-transform: $transform;
+}
+
+@mixin radius-padding($radius, $padding) {
+  border-radius: $radius;
+  padding: $padding;
+}
+
+.button {
+  width: 100%;
+  height: 50px;
+  @include radius-padding(10px, 10px);
+  border: none;
+  @include transition;
+  font-size: 18px;
+  letter-spacing: 5px;
+  color: $dark-grey;
+  @include text-transform(uppercase);
+  &.start-btn {
+    width: 550px;
+  }
+
+  &:hover {
+    cursor: pointer;
+    color: $text-color;
+    background-color: $main-green;
+    box-shadow: 0px 10px 20px rgba(46, 229, 157, 0.4);
+    @include transition;
+  }
+
+  &:disabled {
+    cursor: default;
+    color: inherit;
+    background: #f0f0f0;
+    box-shadow: none;
+    opacity: 0.5;
+  }
+}

--- a/rss-puzzle/src/components/customButton/customButton.ts
+++ b/rss-puzzle/src/components/customButton/customButton.ts
@@ -1,0 +1,27 @@
+import createElement from 'helpers/createElement';
+import { Configurate } from 'types/interfaces';
+import './customButton.scss';
+
+class CustomButton {
+  configurate: Configurate;
+
+  callback?: () => void;
+
+  constructor(configurate: Configurate, callback?: () => void) {
+    this.configurate = configurate;
+    this.callback = callback;
+  }
+
+  render(): HTMLElement {
+    const { element, attributes, textContent } = this.configurate;
+    const button = createElement(element, attributes, textContent);
+
+    if (this.callback) {
+      button.addEventListener('click', this.callback);
+    }
+
+    return button;
+  }
+}
+
+export default CustomButton;

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -1,8 +1,12 @@
 import { State } from 'types/interfaces';
 
+type PageType = 'login' | 'start' | 'main';
+
 type StateApp = {
   user: State;
   updateState(user: State): void;
+  updatePage(page: PageType): void;
+  currentPage: PageType;
 };
 
 const initialState: StateApp = {
@@ -10,9 +14,13 @@ const initialState: StateApp = {
     name: '',
     surname: '',
   },
+  currentPage: 'login',
 
   updateState(user): void {
     this.user = user;
+  },
+  updatePage(page: PageType): void {
+    this.currentPage = page;
   },
 };
 

--- a/rss-puzzle/src/types/interfaces.ts
+++ b/rss-puzzle/src/types/interfaces.ts
@@ -22,4 +22,18 @@ interface InputClassType {
   getState(): State;
 }
 
-export { Login, LoginFormType, InputClassType, State, BaseClass, ContentInfo };
+interface Configurate {
+  element: string;
+  attributes?: Record<string, string>;
+  textContent?: string;
+}
+
+export {
+  Login,
+  LoginFormType,
+  InputClassType,
+  State,
+  BaseClass,
+  ContentInfo,
+  Configurate,
+};

--- a/rss-puzzle/tsconfig.json
+++ b/rss-puzzle/tsconfig.json
@@ -14,6 +14,7 @@
       "helpers/*": ["helpers/*"],
       "types/*": ["types/*"],
       "state/*": ["state/*"],
+      "components/*": ["components/*"],
     },
     "outDir": "./dist",
   },

--- a/rss-puzzle/webpack.config.js
+++ b/rss-puzzle/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = {
       helpers: path.resolve(__dirname, './src/helpers'),
       types: path.resolve(__dirname, './src/types'),
       state: path.resolve(__dirname, './src/state'),
+      components: path.resolve(__dirname, './src/components'),
     },
   },
   plugins: [


### PR DESCRIPTION
## Pull Request - Include a 'Start' Button on Start Screen ([feat: RSS-PZ-07](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-07.md))

### Overview

This pull request introduces the implementation to add  a 'Start' button on the application's start screen, which when clicked, navigates the user to the main game page.

### Features Implemented

-[x] add new component for button (CustomButton);
- [x] add on start page 'Start' button with logic for go to 'Main' page
- [x] add empy 'Main' page for implement to implement the transition in this page
- [x]  update the button creation method Login page with help 'CustomButton'.

### Screenshots
![start button](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/b0556ad3-bda8-4303-b74a-cd82bf6da0e9)
