### PR TITLE
Feat: RSS-PZ-04 restrict functionality logout process

### DIFF
--- a/rss-puzzle/src/app/app.ts
+++ b/rss-puzzle/src/app/app.ts
@@ -50,7 +50,7 @@ class App {
       const userInfo = JSON.parse(state);
       const { user, currentPage } = userInfo;
       initialState.updateState(user, currentPage);
-      this.renderPage(currentPage, root);
+      this.renderPage('start', root);
     } else {
       this.login.draw(root);
     }

--- a/rss-puzzle/src/app/app.ts
+++ b/rss-puzzle/src/app/app.ts
@@ -1,5 +1,5 @@
 import createElement from 'helpers/createElement';
-import { Login, BaseClass } from 'types/interfaces';
+import { Login, BaseClass, PadeId } from 'types/interfaces';
 import { initialState } from 'state/initialState';
 import LoginPage from './pages/login/login';
 import StartPage from './pages/startPage/startPage';
@@ -13,30 +13,47 @@ class App {
   mainPage: BaseClass;
 
   constructor() {
-    this.login = new LoginPage();
+    this.login = new LoginPage(this.changePage);
     this.startPage = new StartPage(this.changePage);
-    this.mainPage = new MainPage();
+    this.mainPage = new MainPage(this.changePage);
   }
 
   public start(): void {
     const root = createElement('div', { id: 'root' });
     document.body.append(root);
-
-    const state = localStorage.getItem('rss-puzzle-login');
-    if (state) {
-      const userInfo = JSON.parse(state);
-      initialState.updateState(userInfo);
-    }
-
-    this.login.draw(root);
+    this.checkLogin(root);
   }
 
-  changePage = (): void => {
+  changePage = (padeId: string): void => {
     const root = document.getElementById('root');
     if (root instanceof HTMLElement) {
       root.innerHTML = '';
-      this.mainPage.draw(root);
+      this.renderPage(padeId, root);
     }
   };
+
+  private renderPage(padeId: string, root: HTMLElement): void {
+    if (PadeId.Start === padeId) {
+      this.startPage.draw(root);
+    }
+    if (PadeId.Main === padeId) {
+      this.mainPage.draw(root);
+    }
+    if (PadeId.Login === padeId) {
+      this.login.draw(root);
+    }
+  }
+
+  private checkLogin(root: HTMLElement): void {
+    const state = localStorage.getItem('rss-puzzle-login');
+    if (state) {
+      const userInfo = JSON.parse(state);
+      const { user, currentPage } = userInfo;
+      initialState.updateState(user, currentPage);
+      this.renderPage(currentPage, root);
+    } else {
+      this.login.draw(root);
+    }
+  }
 }
 export default App;

--- a/rss-puzzle/src/app/pages/login/login.ts
+++ b/rss-puzzle/src/app/pages/login/login.ts
@@ -6,8 +6,11 @@ import './login.scss';
 class LoginPage implements Login {
   loginForm: LoginFormType;
 
-  constructor() {
-    this.loginForm = new LoginForm();
+  callback: (padeId: string) => void;
+
+  constructor(callback: (padeId: string) => void) {
+    this.callback = callback;
+    this.loginForm = new LoginForm(this.callback);
   }
 
   draw(root: HTMLElement): void {

--- a/rss-puzzle/src/app/pages/login/loginForm/loginForm.ts
+++ b/rss-puzzle/src/app/pages/login/loginForm/loginForm.ts
@@ -8,8 +8,11 @@ import './loginForm.scss';
 class LoginForm implements LoginFormType {
   input: InputClassType;
 
-  constructor() {
+  callback: (padeId: string) => void;
+
+  constructor(callback: (padeId: string) => void) {
     this.input = new InputClass();
+    this.callback = callback;
   }
 
   draw(parent: HTMLElement): void {
@@ -34,15 +37,16 @@ class LoginForm implements LoginFormType {
 
     [button.render(), ...inputTags].forEach((element) => form.prepend(element));
 
-    form.addEventListener('submit', this.callback.bind(this));
+    form.addEventListener('submit', this.submitLoginForm.bind(this));
 
     return form;
   }
 
-  private callback(event: SubmitEvent): void {
+  private submitLoginForm(event: SubmitEvent): void {
     event.preventDefault();
     const state = this.input.getState();
-    saveUserData(state);
+    saveUserData(state, 'start');
+    this.callback('start');
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/header/header.ts
+++ b/rss-puzzle/src/app/pages/mainPage/header/header.ts
@@ -1,0 +1,39 @@
+import createElement from 'helpers/createElement';
+import { initialState } from 'state/initialState';
+import icon from 'assets/logout.svg';
+
+class Header {
+  callback: (padeId: string) => void;
+
+  constructor(callback: (padeId: string) => void) {
+    this.callback = callback;
+  }
+
+  draw(root: HTMLElement): void {
+    const header = createElement('header', { class: 'header' });
+
+    const logoutBtn = createElement('button', { class: 'logout-btn' });
+    const iconBtn = createElement('img', {
+      class: 'logout-icon',
+      alt: 'logout',
+    });
+    if (iconBtn instanceof HTMLImageElement) {
+      iconBtn.src = icon;
+    }
+
+    logoutBtn.addEventListener('click', this.singOut.bind(this));
+
+    logoutBtn.append(iconBtn);
+    header.append(logoutBtn);
+
+    root.append(header);
+  }
+
+  singOut(): void {
+    localStorage.removeItem('rss-puzzle-login');
+    initialState.updateState(null, 'login');
+    this.callback('login');
+  }
+}
+
+export default Header;

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.scss
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.scss
@@ -9,6 +9,39 @@
   width: 100vw;
   height: 100vh;
   @include flex;
-  background: #444;
+  justify-content: flex-start;
+  background: url('../../../assets/start-page.jpg') center center;
+  background-size: cover;
   color: #fff;
+  gap: 10px;
+}
+
+.header {
+  width: 100%;
+  height: 60px;
+  padding: 0 10px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.logout-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #fff;
+  padding: 5px;
+  border: none;
+  border-radius: 5px;
+  transition: 0.5s ease-in;
+  &:hover {
+    transition: 0.5s ease-in;
+    cursor: pointer;
+    background: #2ee59d;
+  }
+}
+
+.logout-icon {
+  height: 25px;
 }

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.ts
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.ts
@@ -1,9 +1,21 @@
 import createElement from 'helpers/createElement';
+import { BaseClass } from 'types/interfaces';
+import Header from './header/header';
 import './mainPage.scss';
 
 class MainPage {
+  callback: (padeId: string) => void;
+
+  header: BaseClass;
+
+  constructor(callback: (padeId: string) => void) {
+    this.callback = callback;
+    this.header = new Header(this.callback);
+  }
+
   draw(root: HTMLElement): void {
-    const startPage = createElement('div', { class: 'main-page' }, 'Main Page');
+    const startPage = createElement('div', { class: 'main-page' });
+    this.header.draw(startPage);
     root.append(startPage);
   }
 }

--- a/rss-puzzle/src/app/pages/startPage/startPage.ts
+++ b/rss-puzzle/src/app/pages/startPage/startPage.ts
@@ -1,6 +1,7 @@
 import createElement from 'helpers/createElement';
 import { BaseClass } from 'types/interfaces';
 import { initialState } from 'state/initialState';
+import { saveUserData } from 'helpers/saveUserData';
 import CustomButton from 'components/customButton/customButton';
 import GameInfo from './gameInfo/gameInfo';
 import UserInfo from './userInfo/userInfo';
@@ -14,9 +15,9 @@ class StartPage {
 
   contentBlocks: string[];
 
-  callback: () => void;
+  callback: (padeId: string) => void;
 
-  constructor(callback: () => void) {
+  constructor(callback: (padeId: string) => void) {
     this.content = new GameInfo();
     this.userGreeting = new UserInfo();
     this.contentBlocks = ['start', 'user'];
@@ -49,12 +50,10 @@ class StartPage {
   }
 
   private playApp(): void {
-    localStorage.setItem(
-      'rss-puzzle-login',
-      JSON.stringify({ ...initialState, currentPage: 'main' })
-    );
-    initialState.updatePage('main');
-    this.callback();
+    if (initialState.user) {
+      saveUserData(initialState.user, 'main');
+    }
+    this.callback('main');
   }
 }
 

--- a/rss-puzzle/src/assets/logout.svg
+++ b/rss-puzzle/src/assets/logout.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="533.333px" height="533.333px" viewBox="0 0 533.333 533.333" style="enable-background:new 0 0 533.333 533.333;"
+	 xml:space="preserve">
+<g>
+	<path d="M416.667,333.333v-66.666H250V200h166.667v-66.667l100,100L416.667,333.333z M383.333,300v133.333H216.667v100l-200-100V0
+		h366.667v166.667H350V33.333H83.333L216.667,100v300H350V300H383.333z"/>
+</g>
+</svg>

--- a/rss-puzzle/src/helpers/saveUserData.ts
+++ b/rss-puzzle/src/helpers/saveUserData.ts
@@ -1,8 +1,11 @@
 import { initialState } from 'state/initialState';
 import { State } from 'types/interfaces';
 
-function saveUserData(state: State): void {
-  localStorage.setItem('rss-puzzle-login', JSON.stringify(state));
+function saveUserData(state: State, currentPage: string): void {
+  localStorage.setItem(
+    'rss-puzzle-login',
+    JSON.stringify({ user: state, currentPage })
+  );
   initialState.updateState(state);
 }
 

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -3,8 +3,8 @@ import { State } from 'types/interfaces';
 type PageType = 'login' | 'start' | 'main';
 
 type StateApp = {
-  user: State;
-  updateState(user: State): void;
+  user: State | null;
+  updateState(user: State | null, page?: PageType): void;
   updatePage(page: PageType): void;
   currentPage: PageType;
 };
@@ -16,8 +16,11 @@ const initialState: StateApp = {
   },
   currentPage: 'login',
 
-  updateState(user): void {
+  updateState(user, page?: PageType): void {
     this.user = user;
+    if (page) {
+      this.currentPage = page;
+    }
   },
   updatePage(page: PageType): void {
     this.currentPage = page;

--- a/rss-puzzle/src/types/interfaces.ts
+++ b/rss-puzzle/src/types/interfaces.ts
@@ -5,6 +5,12 @@ type State = {
 
 type ContentInfo = { className: string; description: string };
 
+enum PadeId {
+  Start = 'start',
+  Main = 'main',
+  Login = 'login',
+}
+
 interface Login {
   loginForm: LoginFormType;
   draw(root: HTMLElement): void;
@@ -36,4 +42,5 @@ export {
   BaseClass,
   ContentInfo,
   Configurate,
+  PadeId,
 };


### PR DESCRIPTION
## Pull Request - implement restrict functionality logout process ([feat: RSS-PZ-04](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-04.md))

### Overview

In this Pull Request implementation the application's core features are accessible solely to logged-in users. It necessitates the implementation of a logout mechanism that erases the user's first name and surname from local storage, subsequently redirecting them to the login page.  if a user is already logged in, they should be directly navigated to the start screen, bypassing the login interface.


### Features Implemented

- [x] check availability of username in local storage.
- [x] Redirect users to the login page and restricting access to the application's primary features.
- [x] Automatically direct users with stored login credentials to the start screen
- [x] add button for logout app 

### Screenshots
![main](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/8a0b4bb8-f56e-4dff-a790-144f168b20fb)

