### PR TITLE
Feat: RSS-PZ-08 main page word cards

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
@@ -1,0 +1,47 @@
+.game-container {
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.cards-block,
+.result-block {
+  height: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+  gap: 5px;
+  border-radius: 10px;
+  background: #2ee59d;
+}
+
+.card-wrap {
+  min-width: 30px;
+  height: 37px;
+  border-radius: 5px;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+.card-word {
+  padding: 5px 10px;
+  border-radius: 5px;
+  background: #444;
+  font-size: 24px;
+  transform: translateY(0px);
+  transition: 0.3s ease-in;
+  &:hover {
+    transition: 0.3s ease-in;
+    cursor: pointer;
+    transform: translateY(-5px);
+  }
+}
+
+.card-word:hover .card-wrap {
+  transition: 0.3s ease-in;
+  transform: translateY(-5px);
+}

--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -1,0 +1,33 @@
+import createElement from 'helpers/createElement';
+import { getRounds, initialState } from 'state/initialState';
+import './gameBlock.scss';
+import CardWord from 'components/cardWord/cardWord';
+import wordsRandomOrder from 'helpers/wordsRandomOrder';
+
+class GameBlock {
+  async draw(root: HTMLElement): Promise<void> {
+    await getRounds();
+    const container = createElement('div', { class: 'game-container' });
+    const cardsBlock = createElement('div', { class: 'cards-block' });
+    const resultBlock = createElement('div', { class: 'result-block' });
+
+    if (initialState.roundsData) {
+      const { rounds } = initialState.roundsData;
+      const wordArray = rounds[0].words[0].textExample.split(' ');
+
+      initialState.changeGameStatus({ count: 0, limit: wordArray.length - 1 });
+
+      wordsRandomOrder(wordArray).forEach((word, posiiton) => {
+        const card = new CardWord(word);
+        card.draw(resultBlock, 'result', posiiton);
+        card.draw(cardsBlock, 'random', posiiton);
+      });
+    }
+
+    container.append(resultBlock);
+    container.append(cardsBlock);
+    root.append(container);
+  }
+}
+
+export default GameBlock;

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.scss
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.scss
@@ -13,7 +13,6 @@
   background: url('../../../assets/start-page.jpg') center center;
   background-size: cover;
   color: #fff;
-  gap: 10px;
 }
 
 .header {

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.ts
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.ts
@@ -1,6 +1,7 @@
 import createElement from 'helpers/createElement';
 import { BaseClass } from 'types/interfaces';
 import Header from './header/header';
+import GameBlock from './gameBlock/gameBlock';
 import './mainPage.scss';
 
 class MainPage {
@@ -8,15 +9,19 @@ class MainPage {
 
   header: BaseClass;
 
+  gameBlock: BaseClass;
+
   constructor(callback: (padeId: string) => void) {
     this.callback = callback;
     this.header = new Header(this.callback);
+    this.gameBlock = new GameBlock();
   }
 
   draw(root: HTMLElement): void {
-    const startPage = createElement('div', { class: 'main-page' });
-    this.header.draw(startPage);
-    root.append(startPage);
+    const mainPage = createElement('div', { class: 'main-page' });
+    this.header.draw(mainPage);
+    this.gameBlock.draw(mainPage);
+    root.append(mainPage);
   }
 }
 

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -1,0 +1,62 @@
+import createElement from 'helpers/createElement';
+import { initialState } from 'state/initialState';
+
+class CardWord {
+  card: string;
+
+  constructor(card: string) {
+    this.card = card;
+  }
+
+  async draw(
+    root: HTMLElement,
+    typeBlock: 'result' | 'random',
+    posiiton: number
+  ): Promise<void> {
+    const wrap = createElement('div', {
+      class: 'card-wrap',
+      'data-index': `${posiiton}`,
+    });
+    let card = null;
+
+    if (typeBlock === 'random') {
+      const attributes: Record<string, string> = {
+        class: 'card-word',
+        'data-word': this.card,
+        'data-position': `${posiiton}`,
+      };
+
+      card = createElement('div', attributes, this.card);
+      card.addEventListener('click', this.chooseCard.bind(this));
+      wrap.append(card);
+    }
+    root.append(wrap);
+  }
+
+  chooseCard(event: Event): void {
+    event.preventDefault();
+    const { limit, count } = initialState.gameStatus;
+
+    if (limit >= count) {
+      const block = document.querySelector('.result-block');
+
+      if (!(event.target instanceof HTMLElement)) {
+        throw new Error('Element not found');
+      }
+
+      const element: HTMLElement = event.target;
+
+      if (block) {
+        const item = block.querySelector(`[data-index='${count}']`);
+
+        if (item) {
+          item.append(element);
+        }
+
+        initialState.gameStatus.count += 1;
+      }
+    }
+  }
+}
+
+export default CardWord;

--- a/rss-puzzle/src/helpers/wordsRandomOrder.ts
+++ b/rss-puzzle/src/helpers/wordsRandomOrder.ts
@@ -1,0 +1,5 @@
+function wordsRandomOrder(words: string[]): string[] {
+  return words.sort(() => 0.5 - Math.random());
+}
+
+export default wordsRandomOrder;

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -1,12 +1,39 @@
-import { State } from 'types/interfaces';
+import { State, WordType } from 'types/interfaces';
 
 type PageType = 'login' | 'start' | 'main';
+
+type GameStatusType = {
+  count: number;
+  limit: number;
+};
 
 type StateApp = {
   user: State | null;
   updateState(user: State | null, page?: PageType): void;
-  updatePage(page: PageType): void;
+  updateRounds(data: RoundsData): void;
   currentPage: PageType;
+  roundsData: RoundsData | null;
+  gameStatus: GameStatusType;
+  changeGameStatus(data: GameStatusType): void;
+};
+
+type LevelDataType = {
+  author: string;
+  cutSrc: string;
+  id: string;
+  imageSrc: string;
+  name: string;
+  year: string;
+};
+
+type Round = {
+  levelData: LevelDataType;
+  words: WordType[];
+};
+
+type RoundsData = {
+  roundsCount: number;
+  rounds: Round[];
 };
 
 const initialState: StateApp = {
@@ -14,7 +41,12 @@ const initialState: StateApp = {
     name: '',
     surname: '',
   },
+  gameStatus: {
+    count: 0,
+    limit: 0,
+  },
   currentPage: 'login',
+  roundsData: null,
 
   updateState(user, page?: PageType): void {
     this.user = user;
@@ -22,9 +54,23 @@ const initialState: StateApp = {
       this.currentPage = page;
     }
   },
-  updatePage(page: PageType): void {
-    this.currentPage = page;
+  updateRounds(data: RoundsData): void {
+    this.roundsData = data;
+  },
+  changeGameStatus(data: GameStatusType): void {
+    this.gameStatus = data;
   },
 };
 
-export { initialState };
+async function getRounds(): Promise<void> {
+  await fetch(
+    'https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/data/wordCollectionLevel1.json'
+  )
+    .then((response) => response.json())
+    .then((data: RoundsData) => {
+      initialState.updateRounds(data);
+    })
+    .catch((err) => new Error(err));
+}
+
+export { initialState, getRounds };

--- a/rss-puzzle/src/types/interfaces.ts
+++ b/rss-puzzle/src/types/interfaces.ts
@@ -34,6 +34,15 @@ interface Configurate {
   textContent?: string;
 }
 
+interface WordType {
+  audioExample: string;
+  id: number;
+  textExample: string;
+  textExampleTranslate: string;
+  word: string;
+  wordTranslate: string;
+}
+
 export {
   Login,
   LoginFormType,
@@ -43,4 +52,5 @@ export {
   ContentInfo,
   Configurate,
   PadeId,
+  WordType,
 };


### PR DESCRIPTION
## Pull Request - Design Main Game Page with Interactive Word Cards ([feat: RSS-PZ-08](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-08.md))

### Overview

In this Pull Request add individual words card on main game page, each representing a word from a given sentence. These cards be initially presented in a random order within a source data block. 


### Features Implemented

- [x] Break down a provided sentence into individual words, each word becomes a separate card displayed in the source data block.
- [x] add function for random order cards
- [x] add result block and source block with cards
- [x] add logic for move from the source block to the result block, maintaining the clicked order

### Screenshots
![task-8](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/b3643f42-f8ac-4a76-97bb-df36ddccf6c2)

