### PR TITLE
Feat: RSS-PZ-10 reversible interaction

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
@@ -8,7 +8,7 @@
   gap: 15px;
 }
 
-.cards-block,
+.source-block,
 .result-block {
   height: 60px;
   display: flex;

--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -8,7 +8,7 @@ class GameBlock {
   async draw(root: HTMLElement): Promise<void> {
     await getRounds();
     const container = createElement('div', { class: 'game-container' });
-    const cardsBlock = createElement('div', { class: 'cards-block' });
+    const cardsBlock = createElement('div', { class: 'source-block' });
     const resultBlock = createElement('div', { class: 'result-block' });
 
     if (initialState.roundsData) {
@@ -20,7 +20,7 @@ class GameBlock {
       wordsRandomOrder(wordArray).forEach((word, posiiton) => {
         const card = new CardWord(word);
         card.draw(resultBlock, 'result', posiiton);
-        card.draw(cardsBlock, 'random', posiiton);
+        card.draw(cardsBlock, 'source', posiiton);
       });
     }
 

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -10,7 +10,7 @@ class CardWord {
 
   async draw(
     root: HTMLElement,
-    typeBlock: 'result' | 'random',
+    typeBlock: 'result' | 'source',
     posiiton: number
   ): Promise<void> {
     const wrap = createElement('div', {
@@ -19,7 +19,7 @@ class CardWord {
     });
     let card = null;
 
-    if (typeBlock === 'random') {
+    if (typeBlock === 'source') {
       const attributes: Record<string, string> = {
         class: 'card-word',
         'data-word': this.card,

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -1,5 +1,4 @@
 import createElement from 'helpers/createElement';
-import { initialState } from 'state/initialState';
 
 class CardWord {
   card: string;
@@ -13,13 +12,21 @@ class CardWord {
     typeBlock: 'result' | 'source',
     posiiton: number
   ): Promise<void> {
-    const wrap = createElement('div', {
+    const attributesWrap = {
       class: 'card-wrap',
       'data-index': `${posiiton}`,
+    };
+
+    let wrap = createElement('div', {
+      ...attributesWrap,
+      'data-status': 'empty',
     });
+
     let card = null;
 
     if (typeBlock === 'source') {
+      wrap = createElement('div', attributesWrap);
+
       const attributes: Record<string, string> = {
         class: 'card-word',
         'data-word': this.card,
@@ -35,26 +42,35 @@ class CardWord {
 
   chooseCard(event: Event): void {
     event.preventDefault();
-    const { limit, count } = initialState.gameStatus;
+    if (!(event.target instanceof HTMLElement)) {
+      throw new Error('Element not found');
+    }
 
-    if (limit >= count) {
-      const block = document.querySelector('.result-block');
+    const element = event.target;
 
-      if (!(event.target instanceof HTMLElement)) {
-        throw new Error('Element not found');
+    const resultBlock = document.querySelector('.result-block');
+    const sourceBlock = document.querySelector('.source-block');
+    const isResultBlock = resultBlock?.contains(event.target);
+
+    if (resultBlock && !isResultBlock) {
+      const item = resultBlock.querySelector(`[data-status='empty']`);
+      if (item) {
+        item.append(element);
+        item.setAttribute('data-status', 'full');
+      }
+    }
+    if (isResultBlock && sourceBlock) {
+      const positionWord = event.target.dataset.position;
+      const resultWrap: HTMLElement | null = event.target.parentElement;
+
+      if (resultWrap) {
+        resultWrap.setAttribute('data-status', 'empty');
       }
 
-      const element: HTMLElement = event.target;
-
-      if (block) {
-        const item = block.querySelector(`[data-index='${count}']`);
-
-        if (item) {
-          item.append(element);
-        }
-
-        initialState.gameStatus.count += 1;
-      }
+      const cardWrap = sourceBlock.querySelector(
+        `[data-index='${positionWord}']`
+      );
+      cardWrap?.append(event.target);
     }
   }
 }


### PR DESCRIPTION
## Pull Request - Enable Reversible Interaction with Word Cards Between Blocks ([feat: RSS-PZ-10](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-10.md))

### Overview

In this Pull Request implemented enabling word cards in the result block to be clicked and moved back to the source data block.

### Features Implemented

- [x] add click functionality on word cards in the result block.
- [x] cards in the result block to be moved back to the source block upon clicking.
- [x] a word card is moved back to the source block to placed in the order it was clicked, relative to other returned cards.
- [x]  the result block handles the empty state gracefully.

### Screenshots
![image](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/9b9aeebe-0d99-4fe8-981a-86313cc97c22)
