### PR TITLE
Feat: RSS-PZ-11 add continue button

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
@@ -8,16 +8,31 @@
   gap: 15px;
 }
 
+.results-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+  min-height: 60px;
+}
+
+.source-block,
+.results-container {
+  padding: 10px;
+  border-radius: 10px;
+  background: #2ee59d;
+}
+
+.source-block {
+  height: 60px;
+}
+
 .source-block,
 .result-block {
-  height: 60px;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 10px;
   gap: 5px;
-  border-radius: 10px;
-  background: #2ee59d;
 }
 
 .card-wrap {

--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -28,7 +28,7 @@ class GameBlock {
         attributes: { class: 'button continue-btn', disabled: 'disabled' },
         textContent: 'Continue',
       },
-      this.continueGame
+      (event) => this.continueGame.bind(this)(event)
     );
 
     this.renderBlockWords(resultBlock, cardsBlock);
@@ -71,8 +71,28 @@ class GameBlock {
     });
   }
 
-  continueGame(): void {
-    console.log('continueGame');
+  continueGame(event: Event): void {
+    if (event.target instanceof HTMLElement) {
+      event.target.setAttribute('disabled', 'disabled');
+    }
+
+    initialState.updateCurrentSentence();
+
+    const resultBlock = document.querySelector('.result-block');
+    if (resultBlock) {
+      resultBlock.classList.add('completed');
+    }
+
+    const sourceBlock: HTMLElement | null =
+      document.querySelector('.source-block');
+    const resultItem = this.createResultBlock();
+
+    if (sourceBlock) {
+      sourceBlock.innerHTML = '';
+      this.renderBlockWords(resultItem, sourceBlock);
+    }
+
+    this.containerResults.append(resultItem);
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -3,6 +3,7 @@ import { getRounds, initialState } from 'state/initialState';
 import './gameBlock.scss';
 import CardWord from 'components/cardWord/cardWord';
 import wordsRandomOrder from 'helpers/wordsRandomOrder';
+import CustomButton from 'components/customButton/customButton';
 
 class GameBlock {
   async draw(root: HTMLElement): Promise<void> {
@@ -24,9 +25,23 @@ class GameBlock {
       });
     }
 
-    container.append(resultBlock);
-    container.append(cardsBlock);
+    const button = new CustomButton(
+      {
+        element: 'button',
+        attributes: { class: 'button continue-btn', disabled: 'disabled' },
+        textContent: 'Continue',
+      },
+      this.continueGame.bind(this)
+    );
+
+    [resultBlock, cardsBlock, button.render()].forEach((item) =>
+      container.append(item)
+    );
     root.append(container);
+  }
+
+  continueGame(): void {
+    console.log('continueGame');
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -6,24 +6,21 @@ import wordsRandomOrder from 'helpers/wordsRandomOrder';
 import CustomButton from 'components/customButton/customButton';
 
 class GameBlock {
+  containerResults: HTMLElement;
+
+  constructor() {
+    this.containerResults = createElement('div', {
+      class: 'results-container',
+    });
+  }
+
   async draw(root: HTMLElement): Promise<void> {
     await getRounds();
+    const { containerResults } = this;
     const container = createElement('div', { class: 'game-container' });
+
     const cardsBlock = createElement('div', { class: 'source-block' });
-    const resultBlock = createElement('div', { class: 'result-block' });
-
-    if (initialState.roundsData) {
-      const { rounds } = initialState.roundsData;
-      const wordArray = rounds[0].words[0].textExample.split(' ');
-
-      initialState.changeGameStatus({ count: 0, limit: wordArray.length - 1 });
-
-      wordsRandomOrder(wordArray).forEach((word, posiiton) => {
-        const card = new CardWord(word);
-        card.draw(resultBlock, 'result', posiiton);
-        card.draw(cardsBlock, 'source', posiiton);
-      });
-    }
+    const resultBlock = this.createResultBlock();
 
     const button = new CustomButton(
       {
@@ -31,13 +28,47 @@ class GameBlock {
         attributes: { class: 'button continue-btn', disabled: 'disabled' },
         textContent: 'Continue',
       },
-      this.continueGame.bind(this)
+      this.continueGame
     );
 
-    [resultBlock, cardsBlock, button.render()].forEach((item) =>
+    this.renderBlockWords(resultBlock, cardsBlock);
+    containerResults.append(resultBlock);
+
+    [containerResults, cardsBlock, button.render()].forEach((item) =>
       container.append(item)
     );
+
     root.append(container);
+  }
+
+  renderBlockWords(
+    result: HTMLElement | null,
+    source: HTMLElement | null
+  ): void {
+    if (initialState.currentSentence) {
+      const { textExample } = initialState.currentSentence;
+      const wordArray = textExample.split(' ');
+      console.log(textExample);
+      initialState.changeGameStatus({ count: 0, limit: wordArray.length - 1 });
+
+      wordsRandomOrder(wordArray).forEach((word, position) => {
+        const card = new CardWord(word);
+        if (result) {
+          card.draw(result, 'result', position);
+        }
+        if (source) {
+          card.draw(source, 'source', position);
+        }
+      });
+    }
+  }
+
+  createResultBlock(): HTMLElement {
+    const resultBlockId = initialState.currentSentence?.id;
+    return createElement('div', {
+      class: 'result-block',
+      'data-result_id': `${resultBlockId}`,
+    });
   }
 
   continueGame(): void {

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -1,4 +1,5 @@
 import createElement from 'helpers/createElement';
+import { initialState } from 'state/initialState';
 
 class CardWord {
   card: string;
@@ -46,31 +47,48 @@ class CardWord {
       throw new Error('Element not found');
     }
 
-    const element = event.target;
-
-    const resultBlock = document.querySelector('.result-block');
+    const resultId = initialState.currentSentence?.id;
+    const resultBlock = document.querySelector(
+      `[data-result_id='${resultId}']`
+    );
     const sourceBlock = document.querySelector('.source-block');
     const isResultBlock = resultBlock?.contains(event.target);
+    const isCompleted = !!event.target.closest('.completed');
 
-    if (resultBlock && !isResultBlock) {
-      const item = resultBlock.querySelector(`[data-status='empty']`);
-      if (item) {
-        item.append(element);
-        item.setAttribute('data-status', 'full');
-      }
+    if (resultBlock && !isResultBlock && !isCompleted) {
+      this.moveToResult(resultBlock, event.target);
     }
+
     if (isResultBlock && sourceBlock) {
-      const positionWord = event.target.dataset.position;
-      const resultWrap: HTMLElement | null = event.target.parentElement;
+      this.moveFromResultToSource(isCompleted, event.target, sourceBlock);
+    }
+  }
+
+  private moveFromResultToSource(
+    isCompleted: boolean,
+    word: HTMLElement,
+    sourceBlock: Element
+  ): void {
+    if (!isCompleted) {
+      const positionWord = word.dataset.position;
+      const resultWrap: HTMLElement | null = word.parentElement;
+      const cardWrap = sourceBlock.querySelector(
+        `[data-index='${positionWord}']`
+      );
 
       if (resultWrap) {
         resultWrap.setAttribute('data-status', 'empty');
       }
 
-      const cardWrap = sourceBlock.querySelector(
-        `[data-index='${positionWord}']`
-      );
-      cardWrap?.append(event.target);
+      cardWrap?.append(word);
+    }
+  }
+
+  private moveToResult(resultBlock: Element, word: HTMLElement): void {
+    const item = resultBlock.querySelector(`[data-status='empty']`);
+    if (item) {
+      item.append(word);
+      item.setAttribute('data-status', 'full');
     }
   }
 }

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -81,6 +81,7 @@ class CardWord {
       }
 
       cardWrap?.append(word);
+      this.changeDisabledContinueBtn(true);
     }
   }
 
@@ -89,6 +90,40 @@ class CardWord {
     if (item) {
       item.append(word);
       item.setAttribute('data-status', 'full');
+    }
+    this.checkCorrectSentence(resultBlock);
+  }
+
+  private checkCorrectSentence(resultBlock: Element): void {
+    const isFullSentence =
+      resultBlock.querySelectorAll(`[data-status='empty']`).length === 0;
+
+    if (isFullSentence) {
+      const arrayWords = [...resultBlock.querySelectorAll('.card-word')];
+      const checkSentence = initialState.currentSentence?.textExample;
+
+      const resultSentence = arrayWords
+        .map((wordElement) => {
+          if (!(wordElement instanceof HTMLElement)) {
+            throw new Error('Element not found');
+          }
+          return wordElement.dataset.word;
+        })
+        .join(' ');
+
+      this.changeDisabledContinueBtn(checkSentence !== resultSentence);
+    }
+  }
+
+  changeDisabledContinueBtn(isDisabled: boolean): void {
+    const button = document.querySelector('.continue-btn');
+    if (!(button instanceof HTMLElement)) {
+      throw new Error('Element not found');
+    }
+    if (isDisabled) {
+      button.setAttribute('disabled', 'disabled');
+    } else {
+      button.removeAttribute('disabled');
     }
   }
 }

--- a/rss-puzzle/src/components/customButton/customButton.scss
+++ b/rss-puzzle/src/components/customButton/customButton.scss
@@ -28,6 +28,14 @@ $main-green: #2ee59d;
   &.start-btn {
     width: 550px;
   }
+  &.continue-btn {
+    width: 300px;
+    margin: 0 auto;
+    &:disabled {
+      color: #555;
+      background: #cacaca;
+    }
+  }
 
   &:hover {
     cursor: pointer;

--- a/rss-puzzle/src/components/customButton/customButton.ts
+++ b/rss-puzzle/src/components/customButton/customButton.ts
@@ -5,9 +5,9 @@ import './customButton.scss';
 class CustomButton {
   configurate: Configurate;
 
-  callback?: () => void;
+  callback?: (event: Event) => void;
 
-  constructor(configurate: Configurate, callback?: () => void) {
+  constructor(configurate: Configurate, callback?: (event: Event) => void) {
     this.configurate = configurate;
     this.callback = callback;
   }
@@ -17,7 +17,7 @@ class CustomButton {
     const button = createElement(element, attributes, textContent);
 
     if (this.callback) {
-      button.addEventListener('click', this.callback);
+      button.addEventListener('click', (event) => this.callback?.(event));
     }
 
     return button;

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -13,8 +13,11 @@ type StateApp = {
   updateRounds(data: RoundsData): void;
   currentPage: PageType;
   roundsData: RoundsData | null;
+  currentRound: Round | null;
+  currentSentence: WordType | null;
   gameStatus: GameStatusType;
   changeGameStatus(data: GameStatusType): void;
+  updateCurrentSentence(): void;
 };
 
 type LevelDataType = {
@@ -47,6 +50,8 @@ const initialState: StateApp = {
   },
   currentPage: 'login',
   roundsData: null,
+  currentRound: null,
+  currentSentence: null,
 
   updateState(user, page?: PageType): void {
     this.user = user;
@@ -56,9 +61,24 @@ const initialState: StateApp = {
   },
   updateRounds(data: RoundsData): void {
     this.roundsData = data;
+    const [round] = data.rounds;
+    const [sentence] = round.words;
+    this.currentRound = round;
+    this.currentSentence = sentence;
+    console.log(round, sentence, 'item');
   },
   changeGameStatus(data: GameStatusType): void {
     this.gameStatus = data;
+  },
+  updateCurrentSentence(): void {
+    if (this.currentSentence && this.currentRound) {
+      const { id } = this.currentSentence;
+      const { words } = this.currentRound;
+      const positionWods = words.findIndex((x) => x.id === id);
+      const [current] = words.slice(positionWods + 1);
+      this.currentSentence = current;
+      console.log(this.currentSentence.textExample);
+    }
   },
 };
 


### PR DESCRIPTION
## Pull Request - Implement 'Continue' Button for Sentence Transition and Round Completion ([feat: RSS-PZ-11](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-11.md))

### Overview

In this Pull Request implemented a 'Continue' button within the game interface, which activates only after a sentence is correctly assembled. This button facilitates progression to the next sentence.

### Features Implemented

- [x] add disabled  a 'Continue' button and activated only after verifying the correct assembly of the current sentence.
- [x] Implemented logic to assess the accuracy of the sentence constructed by the player.
- [x] go to next sentence after click 'Continue' button

### Screenshots
![image](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/31adfb81-7230-46d8-b7c0-a5934171ace8)
