### PR TITLE
Feat: RSS-PZ-12 add check button

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.scss
@@ -1,3 +1,9 @@
+@mixin flex {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .game-container {
   width: 100%;
   height: 100%;
@@ -20,7 +26,7 @@
 .results-container {
   padding: 10px;
   border-radius: 10px;
-  background: #2ee59d;
+  background: #2ee59c65;
 }
 
 .source-block {
@@ -29,9 +35,7 @@
 
 .source-block,
 .result-block {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  @include flex;
   gap: 5px;
 }
 
@@ -43,7 +47,10 @@
 }
 
 .card-word {
+  height: 100%;
+  @include flex;
   padding: 5px 10px;
+  box-sizing: border-box;
   border-radius: 5px;
   background: #444;
   font-size: 24px;

--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -4,6 +4,7 @@ import './gameBlock.scss';
 import CardWord from 'components/cardWord/cardWord';
 import wordsRandomOrder from 'helpers/wordsRandomOrder';
 import CustomButton from 'components/customButton/customButton';
+import changeDisabledButton from 'helpers/changeDisabledButton';
 
 class GameBlock {
   containerResults: HTMLElement;
@@ -18,7 +19,6 @@ class GameBlock {
     await getRounds();
     const { containerResults } = this;
     const container = createElement('div', { class: 'game-container' });
-
     const cardsBlock = createElement('div', { class: 'source-block' });
     const resultBlock = this.createResultBlock();
 
@@ -30,13 +30,27 @@ class GameBlock {
       },
       (event) => this.continueGame.bind(this)(event)
     );
+    const checkButton = new CustomButton(
+      {
+        element: 'button',
+        attributes: { class: 'button check-btn', disabled: 'disabled' },
+        textContent: 'Check',
+      },
+      (event) => this.checkSentence.bind(this)(event)
+    );
 
     this.renderBlockWords(resultBlock, cardsBlock);
+    if (containerResults.childNodes.length) {
+      containerResults.innerHTML = '';
+    }
     containerResults.append(resultBlock);
 
-    [containerResults, cardsBlock, button.render()].forEach((item) =>
-      container.append(item)
-    );
+    [
+      containerResults,
+      cardsBlock,
+      button.render(),
+      checkButton.render(),
+    ].forEach((item) => container.append(item));
 
     root.append(container);
   }
@@ -74,14 +88,24 @@ class GameBlock {
   continueGame(event: Event): void {
     if (event.target instanceof HTMLElement) {
       event.target.setAttribute('disabled', 'disabled');
+      changeDisabledButton(true, 'check');
+    }
+
+    const resultBlock = document.querySelector(
+      `[data-result_id='${initialState.currentSentence?.id}']`
+    );
+
+    if (resultBlock) {
+      const words = [...resultBlock.querySelectorAll('.card-word')];
+      [...words].forEach((el) => {
+        const isClue = el.hasAttribute('style');
+        if (isClue) {
+          el.removeAttribute('style');
+        }
+      });
     }
 
     initialState.updateCurrentSentence();
-
-    const resultBlock = document.querySelector('.result-block');
-    if (resultBlock) {
-      resultBlock.classList.add('completed');
-    }
 
     const sourceBlock: HTMLElement | null =
       document.querySelector('.source-block');
@@ -93,6 +117,30 @@ class GameBlock {
     }
 
     this.containerResults.append(resultItem);
+  }
+
+  checkSentence(event: Event): void {
+    event.preventDefault();
+    if (initialState.currentSentence) {
+      const { textExample, id } = initialState.currentSentence;
+      const wordArray = textExample.split(' ');
+      const resultBlock = document.querySelector(`[data-result_id='${id}']`);
+      if (resultBlock) {
+        const words = [...resultBlock.querySelectorAll('.card-word')];
+        [...words].forEach((el, i) => {
+          if (!(el instanceof HTMLElement)) {
+            throw new Error('Element not found');
+          }
+          const word = el;
+          if (el.dataset.word === wordArray[i]) {
+            console.log(el.dataset.word, wordArray[i]);
+            word.style.border = '2px solid #00ff00';
+          } else {
+            word.style.border = '2px solid red';
+          }
+        });
+      }
+    }
   }
 }
 

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -1,3 +1,4 @@
+import changeDisabledButton from 'helpers/changeDisabledButton';
 import createElement from 'helpers/createElement';
 import { initialState } from 'state/initialState';
 
@@ -61,6 +62,10 @@ class CardWord {
 
     if (isResultBlock && sourceBlock) {
       this.moveFromResultToSource(isCompleted, event.target, sourceBlock);
+      const isClue = event.target.hasAttribute('style');
+      if (isClue) {
+        event.target.removeAttribute('style');
+      }
     }
   }
 
@@ -81,7 +86,8 @@ class CardWord {
       }
 
       cardWrap?.append(word);
-      this.changeDisabledContinueBtn(true);
+      changeDisabledButton(true, 'continue');
+      changeDisabledButton(true, 'check');
     }
   }
 
@@ -111,19 +117,8 @@ class CardWord {
         })
         .join(' ');
 
-      this.changeDisabledContinueBtn(checkSentence !== resultSentence);
-    }
-  }
-
-  changeDisabledContinueBtn(isDisabled: boolean): void {
-    const button = document.querySelector('.continue-btn');
-    if (!(button instanceof HTMLElement)) {
-      throw new Error('Element not found');
-    }
-    if (isDisabled) {
-      button.setAttribute('disabled', 'disabled');
-    } else {
-      button.removeAttribute('disabled');
+      changeDisabledButton(checkSentence !== resultSentence, 'continue');
+      changeDisabledButton(false, 'check');
     }
   }
 }

--- a/rss-puzzle/src/components/customButton/customButton.scss
+++ b/rss-puzzle/src/components/customButton/customButton.scss
@@ -28,7 +28,8 @@ $main-green: #2ee59d;
   &.start-btn {
     width: 550px;
   }
-  &.continue-btn {
+  &.continue-btn,
+  &.check-btn {
     width: 300px;
     margin: 0 auto;
     &:disabled {

--- a/rss-puzzle/src/helpers/changeDisabledButton.ts
+++ b/rss-puzzle/src/helpers/changeDisabledButton.ts
@@ -1,0 +1,13 @@
+function changeDisabledButton(isDisabled: boolean, type: string): void {
+  const button = document.querySelector(`.${type}-btn`);
+  if (!(button instanceof HTMLElement)) {
+    throw new Error('Element not found');
+  }
+  if (isDisabled) {
+    button.setAttribute('disabled', 'disabled');
+  } else {
+    button.removeAttribute('disabled');
+  }
+}
+
+export default changeDisabledButton;


### PR DESCRIPTION
## Pull Request - Implement 'Check' Button for Sentence Verification ([feat: RSS-PZ-12](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-12.md))

### Overview

In this Pull Request implemented a 'Check' button in the game, which becomes active or visible only when all the words of a sentence have been moved to the result block. This button serves a critical function by enabling players to verify the correctness of their sentence assembly.

### Features Implemented

- [x] add disabled  a 'Continue' button and activated only after verifying the correct assembly of the current sentence.
- [x] Implemented logic to verify the correctness of the word order.
- [x] add visual cues for indicated words are correctly positioned and which need to be rearranged.

### Screenshots
![image](https://github.com/rolling-scopes-school/oleg-melnikow-JSFE2023Q4/assets/14839880/ff9a8f3c-d689-4021-9b40-a9ba57116b71)
