### PR TITLE
Feat: RSS-PZ-21 toggle visibility pronunciation hint

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/SoundButton/soundButton.scss
+++ b/rss-puzzle/src/app/pages/mainPage/SoundButton/soundButton.scss
@@ -11,6 +11,11 @@
   transition: 0.5s;
   transform: scale(1);
 
+  &.hide {
+    opacity: 0;
+    visibility: hidden;
+  }
+
   &:hover {
     cursor: pointer;
     border-color: #fff;

--- a/rss-puzzle/src/app/pages/mainPage/gameButtons/gameButtons.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameButtons/gameButtons.ts
@@ -76,8 +76,11 @@ class GameButtons {
 
   continueGame(): void {
     if (!initialState.hintVisible) {
-      console.log(!initialState.hintVisible);
-      visibleHint(true);
+      visibleHint(true, 'hint');
+    }
+
+    if (!initialState.soundVisible) {
+      visibleHint(true, 'sound');
     }
 
     const resultBlock = findElement(

--- a/rss-puzzle/src/app/pages/mainPage/header/header.ts
+++ b/rss-puzzle/src/app/pages/mainPage/header/header.ts
@@ -20,11 +20,14 @@ class Header {
     const hintBtn = createElement('button', { class: 'hint-btn' }, 'Hint');
     this.addIconToButton(hintBtn, hintIcon, 'hint');
 
+    const sound = createElement('button', { class: 'sound-btn' });
+    sound.append(createElement('i', { class: 'fa-solid fa-music' }));
+
     logoutBtn.addEventListener('click', this.singOut.bind(this));
     hintBtn.addEventListener('click', (event) => this.hideHint(event));
+    sound.addEventListener('click', (event) => this.hideSound(event));
 
-    header.append(hintBtn);
-    header.append(logoutBtn);
+    [sound, hintBtn, logoutBtn].forEach((button) => header.append(button));
 
     root.append(header);
   }
@@ -36,14 +39,25 @@ class Header {
   }
 
   hideHint(event: Event): void {
-    if (!(event.target instanceof HTMLElement)) {
+    if (!(event.currentTarget instanceof HTMLElement)) {
       throw new Error('Element not found');
     }
-    event.target.classList.toggle('hide');
+    event.currentTarget.classList.toggle('hide');
 
     const hint = findElement('.hint');
     hint.classList.toggle('hide');
     initialState.chnageHindVisible();
+  }
+
+  hideSound(event: Event): void {
+    if (!(event.currentTarget instanceof HTMLElement)) {
+      throw new Error('Element not found');
+    }
+    event.currentTarget.classList.toggle('hide');
+
+    const soundButton = findElement('.sound-button');
+    soundButton.classList.toggle('hide');
+    initialState.chnageSoundVisible();
   }
 
   addIconToButton(button: HTMLElement, image: string, name: string): void {

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.scss
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.scss
@@ -27,7 +27,10 @@
 }
 
 .logout-btn,
-.hint-btn {
+.hint-btn,
+.sound-btn {
+  height: 35px;
+  min-width: 35px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -40,6 +43,7 @@
   font-size: 18px;
   font-weight: bold;
   &:hover {
+    color: #fff;
     transition: 0.5s ease-in;
     cursor: pointer;
     background: #2ee59d;
@@ -52,6 +56,7 @@
 }
 
 .logout-icon,
-.hint-icon {
+.hint-icon,
+.sound-icon {
   height: 25px;
 }

--- a/rss-puzzle/src/components/cardWord/cardWord.ts
+++ b/rss-puzzle/src/components/cardWord/cardWord.ts
@@ -122,8 +122,12 @@ class CardWord {
         transformButton('continue');
         completeSectence(initialState.currentSentence?.id);
         if (!initialState.hintVisible) {
-          visibleHint(false);
+          visibleHint(false, 'hint');
         }
+        if (!initialState.soundVisible) {
+          visibleHint(false, 'sound');
+        }
+        changeDisabledButton(true, '.complete-btn');
       }
       changeDisabledButton(false);
     }

--- a/rss-puzzle/src/helpers/visibleHint.ts
+++ b/rss-puzzle/src/helpers/visibleHint.ts
@@ -1,7 +1,9 @@
 import { findElement } from './findElement';
 
-function visibleHint(isHide: boolean): void {
-  ['.hint-btn', '.hint'].forEach((item) => {
+function visibleHint(isHide: boolean, type: 'hint' | 'sound'): void {
+  const array =
+    type === 'hint' ? ['.hint-btn', '.hint'] : ['.sound-btn', '.sound-button'];
+  array.forEach((item) => {
     const hint = findElement(item);
     if (isHide) {
       hint.classList.add('hide');

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -18,8 +18,10 @@ type StateApp = {
   currentSentence: WordType | null;
   gameStatus: GameStatusType;
   hintVisible: boolean;
+  soundVisible: boolean;
   currentUrlAudio: string;
   chnageHindVisible(): void;
+  chnageSoundVisible(): void;
   changeGameStatus(data: GameStatusType): void;
   updateCurrentSentence(): void;
 };
@@ -57,6 +59,7 @@ const initialState: StateApp = {
   currentRound: null,
   currentSentence: null,
   hintVisible: true,
+  soundVisible: true,
   currentUrlAudio: '',
 
   updateState(user, page?: PageType): void {
@@ -89,6 +92,10 @@ const initialState: StateApp = {
 
   chnageHindVisible(): void {
     this.hintVisible = !this.hintVisible;
+  },
+
+  chnageSoundVisible(): void {
+    this.soundVisible = !this.soundVisible;
   },
 };
 


### PR DESCRIPTION
## Pull Request -Toggle Functionality for Pronunciation Hint Visibility ([feat: RSS-PZ-21](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-21.md))

### Overview

In this Pull Request implemented a toggle feature for the pronunciation hint in the game, allowing players to choose whether the audio button for pronunciation is visible during gameplay

### Features Implemented

- [x] add a toggle control, for players to enable or disable the pronunciation hint.

### Screenshots

![image](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/e028081b-8b6d-4855-ab77-e9ed0d926837)


