### PR TITLE
Feat: RSS-PZ-24 add logic for save status hint buttons in localStorage

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -1,4 +1,5 @@
 import createElement from 'helpers/createElement';
+import visibleHint from 'helpers/visibleHint';
 import { getRounds, getSound, initialState } from 'state/initialState';
 import { BaseClass } from 'types/interfaces';
 import CardWord from 'components/cardWord/cardWord';
@@ -47,6 +48,8 @@ class GameBlock {
     this.gameButtons.draw(container);
 
     root.append(container);
+
+    this.checkControls();
   }
 
   renderBlockWords(
@@ -78,6 +81,18 @@ class GameBlock {
       class: 'result-block',
       'data-result_id': `${resultBlockId}`,
     });
+  }
+
+  private checkControls(): void {
+    const controls = localStorage.getItem('rss-puzzle-controls');
+
+    if (controls) {
+      const { soundVisible, hintVisible } = JSON.parse(controls);
+      initialState.soundVisible = soundVisible;
+      initialState.hintVisible = hintVisible;
+      visibleHint(!soundVisible, 'sound');
+      visibleHint(!hintVisible, 'hint');
+    }
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/header/header.ts
+++ b/rss-puzzle/src/app/pages/mainPage/header/header.ts
@@ -34,6 +34,7 @@ class Header {
 
   singOut(): void {
     localStorage.removeItem('rss-puzzle-login');
+    localStorage.removeItem('rss-puzzle-controls');
     initialState.updateState(null, 'login');
     this.callback('login');
   }

--- a/rss-puzzle/src/helpers/saveUserData.ts
+++ b/rss-puzzle/src/helpers/saveUserData.ts
@@ -9,4 +9,12 @@ function saveUserData(state: State, currentPage: string): void {
   initialState.updateState(state);
 }
 
-export { saveUserData };
+function saveControlsButton(): void {
+  const { hintVisible, soundVisible } = initialState;
+  localStorage.setItem(
+    'rss-puzzle-controls',
+    JSON.stringify({ hintVisible, soundVisible })
+  );
+}
+
+export { saveUserData, saveControlsButton };

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -1,4 +1,5 @@
 import { findElement } from 'helpers/findElement';
+import { saveControlsButton } from 'helpers/saveUserData';
 import { State, WordType } from 'types/interfaces';
 
 type PageType = 'login' | 'start' | 'main';
@@ -92,10 +93,12 @@ const initialState: StateApp = {
 
   chnageHindVisible(): void {
     this.hintVisible = !this.hintVisible;
+    saveControlsButton();
   },
 
   chnageSoundVisible(): void {
     this.soundVisible = !this.soundVisible;
+    saveControlsButton();
   },
 };
 


### PR DESCRIPTION
## Pull Request Hint State Persistence and Default Settings  ([feat: RSS-PZ-24](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-24.md))

### Overview

In this Pull Request implemented a feature to save the state (enabled or disabled) of each hint in local storage, ensuring a personalized and consistent gameplay experience.

### Features Implemented

- [x] save the enabled/disabled state of each hint in localStorage
- [x] add functionality to reset the hint states to their default settings (all enabled) when a user logs out.


