### PR TITLE
Feat: RSS-PZ-25 select levels rounds game

### DIFF
--- a/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameBlock/gameBlock.ts
@@ -1,6 +1,5 @@
 import createElement from 'helpers/createElement';
-import visibleHint from 'helpers/visibleHint';
-import { getRounds, getSound, initialState } from 'state/initialState';
+import { getSound, initialState } from 'state/initialState';
 import { BaseClass } from 'types/interfaces';
 import CardWord from 'components/cardWord/cardWord';
 import wordsRandomOrder from 'helpers/wordsRandomOrder';
@@ -27,8 +26,7 @@ class GameBlock {
     this.soundButton = new SoundButton();
   }
 
-  async draw(root: HTMLElement): Promise<void> {
-    await getRounds();
+  draw(root: HTMLElement): void {
     const { containerResults } = this;
     const container = createElement('div', { class: 'game-container' });
     const cardsBlock = createElement('div', { class: 'source-block' });
@@ -48,8 +46,6 @@ class GameBlock {
     this.gameButtons.draw(container);
 
     root.append(container);
-
-    this.checkControls();
   }
 
   renderBlockWords(
@@ -81,18 +77,6 @@ class GameBlock {
       class: 'result-block',
       'data-result_id': `${resultBlockId}`,
     });
-  }
-
-  private checkControls(): void {
-    const controls = localStorage.getItem('rss-puzzle-controls');
-
-    if (controls) {
-      const { soundVisible, hintVisible } = JSON.parse(controls);
-      initialState.soundVisible = soundVisible;
-      initialState.hintVisible = hintVisible;
-      visibleHint(!soundVisible, 'sound');
-      visibleHint(!hintVisible, 'hint');
-    }
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/gameButtons/gameButtons.ts
+++ b/rss-puzzle/src/app/pages/mainPage/gameButtons/gameButtons.ts
@@ -1,7 +1,5 @@
 import createElement from 'helpers/createElement';
-import { getSound, initialState } from 'state/initialState';
-import CardWord from 'components/cardWord/cardWord';
-import wordsRandomOrder from 'helpers/wordsRandomOrder';
+import { initialState } from 'state/initialState';
 import CustomButton from 'components/customButton/customButton';
 import changeDisabledButton from 'helpers/changeDisabledButton';
 import transformButton from 'helpers/transformButton';
@@ -9,8 +7,9 @@ import { findElement } from 'helpers/findElement';
 import instanceHtml from 'helpers/instanceHtml';
 import removeAttribute from 'helpers/removeAttribute';
 import checkFullSentence from 'helpers/checkFullSentence';
-import './gameButtons.scss';
 import visibleHint from 'helpers/visibleHint';
+import { updatePlayingField } from 'helpers/updatePlayingField';
+import './gameButtons.scss';
 
 class GameButtons {
   draw(root: HTMLElement): void {
@@ -45,35 +44,6 @@ class GameButtons {
     root.append(container);
   }
 
-  renderBlockWords(
-    result: HTMLElement | null,
-    source: HTMLElement | null
-  ): void {
-    if (initialState.currentSentence) {
-      const { textExample } = initialState.currentSentence;
-      const wordArray = textExample.split(' ');
-      initialState.changeGameStatus({ count: 0, limit: wordArray.length - 1 });
-
-      wordsRandomOrder(wordArray).forEach((word, position) => {
-        const card = new CardWord(word);
-        if (result) {
-          card.draw(result, 'result', position);
-        }
-        if (source) {
-          card.draw(source, 'source', position);
-        }
-      });
-    }
-  }
-
-  createResultBlock(): HTMLElement {
-    const resultBlockId = initialState.currentSentence?.id;
-    return createElement('div', {
-      class: 'result-block',
-      'data-result_id': `${resultBlockId}`,
-    });
-  }
-
   continueGame(): void {
     if (!initialState.hintVisible) {
       visibleHint(true, 'hint');
@@ -92,18 +62,7 @@ class GameButtons {
     [...words].forEach((el) => removeAttribute(el, 'style'));
 
     initialState.updateCurrentSentence();
-    this.changeHint(initialState.currentSentence?.textExampleTranslate || '');
-
-    const sourceBlock = findElement('.source-block');
-    sourceBlock.innerHTML = '';
-    const resultItem = this.createResultBlock();
-    this.renderBlockWords(resultItem, sourceBlock);
-
-    findElement('.results-container').append(resultItem);
-    transformButton('check');
-    changeDisabledButton(true);
-
-    getSound(initialState.currentSentence?.audioExample || '');
+    updatePlayingField();
   }
 
   checkSentence(event: Event): void {
@@ -111,7 +70,6 @@ class GameButtons {
     if (!(event.target instanceof HTMLElement)) {
       throw new Error('Element not found');
     }
-    changeDisabledButton(false, '.complete-btn');
     const { button } = event.target.dataset;
 
     if (initialState.currentSentence && button === 'check') {
@@ -192,11 +150,6 @@ class GameButtons {
     });
 
     return resultBlock;
-  }
-
-  changeHint(hint: string): void {
-    const hintElement = findElement('.hint-content');
-    hintElement.textContent = hint;
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/header/header.ts
+++ b/rss-puzzle/src/app/pages/mainPage/header/header.ts
@@ -3,12 +3,17 @@ import { initialState } from 'state/initialState';
 import icon from 'assets/logout.svg';
 import hintIcon from 'assets/hint.png';
 import { findElement } from 'helpers/findElement';
+import { BaseClass } from 'types/interfaces';
+import SelectLevel from '../selectLevel/selectLevel';
 
 class Header {
   callback: (padeId: string) => void;
 
+  selectLevel: BaseClass;
+
   constructor(callback: (padeId: string) => void) {
     this.callback = callback;
+    this.selectLevel = new SelectLevel();
   }
 
   draw(root: HTMLElement): void {
@@ -26,6 +31,8 @@ class Header {
     logoutBtn.addEventListener('click', this.singOut.bind(this));
     hintBtn.addEventListener('click', (event) => this.hideHint(event));
     sound.addEventListener('click', (event) => this.hideSound(event));
+
+    this.selectLevel.draw(header);
 
     [sound, hintBtn, logoutBtn].forEach((button) => header.append(button));
 

--- a/rss-puzzle/src/app/pages/mainPage/mainPage.ts
+++ b/rss-puzzle/src/app/pages/mainPage/mainPage.ts
@@ -1,5 +1,7 @@
 import createElement from 'helpers/createElement';
 import { BaseClass } from 'types/interfaces';
+import { getRounds, initialState } from 'state/initialState';
+import visibleHint from 'helpers/visibleHint';
 import Header from './header/header';
 import GameBlock from './gameBlock/gameBlock';
 import './mainPage.scss';
@@ -17,11 +19,25 @@ class MainPage {
     this.gameBlock = new GameBlock();
   }
 
-  draw(root: HTMLElement): void {
+  async draw(root: HTMLElement): Promise<void> {
+    await getRounds();
     const mainPage = createElement('div', { class: 'main-page' });
     this.header.draw(mainPage);
     this.gameBlock.draw(mainPage);
     root.append(mainPage);
+    this.checkControls();
+  }
+
+  private checkControls(): void {
+    const controls = localStorage.getItem('rss-puzzle-controls');
+
+    if (controls) {
+      const { soundVisible, hintVisible } = JSON.parse(controls);
+      initialState.soundVisible = soundVisible;
+      initialState.hintVisible = hintVisible;
+      visibleHint(!soundVisible, 'sound');
+      visibleHint(!hintVisible, 'hint');
+    }
   }
 }
 

--- a/rss-puzzle/src/app/pages/mainPage/selectLevel/selectLevel.scss
+++ b/rss-puzzle/src/app/pages/mainPage/selectLevel/selectLevel.scss
@@ -1,0 +1,5 @@
+.select-block {
+  display: flex;
+  flex: 1;
+  gap: 10px;
+}

--- a/rss-puzzle/src/app/pages/mainPage/selectLevel/selectLevel.ts
+++ b/rss-puzzle/src/app/pages/mainPage/selectLevel/selectLevel.ts
@@ -1,0 +1,31 @@
+import CustomSelect from 'components/customSelect/customSelect';
+import createElement from 'helpers/createElement';
+import './selectLevel.scss';
+import { initialState } from 'state/initialState';
+
+class SelectLevel {
+  levelsNumber: number;
+
+  constructor() {
+    this.levelsNumber = 6;
+  }
+
+  draw(root: HTMLElement): void {
+    const selectBlock = createElement('div', { class: 'select-block' });
+    const selectLevel = new CustomSelect(this.levelsNumber, 'level');
+
+    selectLevel.draw(selectBlock);
+
+    if (initialState.roundsData?.roundsCount) {
+      const selectRound = new CustomSelect(
+        initialState.roundsData?.roundsCount,
+        'round'
+      );
+      selectRound.draw(selectBlock);
+    }
+
+    root.append(selectBlock);
+  }
+}
+
+export default SelectLevel;

--- a/rss-puzzle/src/components/AudioElement/AudioElement.ts
+++ b/rss-puzzle/src/components/AudioElement/AudioElement.ts
@@ -2,7 +2,6 @@ import { initialState } from 'state/initialState';
 
 class AudioElement {
   draw(root: HTMLElement): void {
-    console.log(root);
     const audio = document.createElement('audio');
     audio.classList.add('sound');
     const source = document.createElement('source');

--- a/rss-puzzle/src/components/customSelect/customSelect.scss
+++ b/rss-puzzle/src/components/customSelect/customSelect.scss
@@ -1,0 +1,29 @@
+.select {
+  width: 200px;
+  height: 35px;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 5px;
+  outline: none;
+  background: #aaa;
+  box-shadow: 0 5px 25px rgba(0, 0, 0, 0.8);
+
+  font-size: 18px;
+  text-transform: capitalize;
+  option {
+    padding: 5px;
+  }
+  option:checked,
+  option:hover {
+    background: #444;
+    color: #cffd16;
+    cursor: pointer;
+  }
+}
+.controls {
+  display: flex;
+  width: 100%;
+  padding: 20px 10px;
+  box-sizing: border-box;
+  border-bottom: 1px solid #ccc;
+}

--- a/rss-puzzle/src/components/customSelect/customSelect.ts
+++ b/rss-puzzle/src/components/customSelect/customSelect.ts
@@ -1,0 +1,49 @@
+import createElement from 'helpers/createElement';
+import { getRounds, initialState } from 'state/initialState';
+import { updatePlayingField } from 'helpers/updatePlayingField';
+import './customSelect.scss';
+
+type TypeSelect = 'level' | 'round';
+
+class CustomSelect {
+  optionsCount: number;
+
+  type: TypeSelect;
+
+  constructor(optionsCount: number, type: TypeSelect) {
+    this.optionsCount = optionsCount;
+    this.type = type;
+  }
+
+  draw(root: HTMLElement): void {
+    const select = createElement('select', {
+      id: 'level',
+      class: 'select',
+    });
+
+    for (let i = 1; i <= this.optionsCount; i += 1) {
+      const element = createElement('option', { value: `${i}` }, `Level ${i}`);
+      select.append(element);
+    }
+
+    select.addEventListener('change', async (event: Event) => {
+      if (event.target instanceof HTMLSelectElement) {
+        const item = event.target;
+        const level = +item.value;
+        if (this.type === 'level') {
+          await getRounds(level);
+        }
+        if (this.type === 'round' && initialState.roundsData) {
+          const currentRound = initialState.roundsData.rounds[level];
+          initialState.updateCurrentRound(currentRound);
+        }
+
+        updatePlayingField(true);
+      }
+    });
+
+    root.append(select);
+  }
+}
+
+export default CustomSelect;

--- a/rss-puzzle/src/helpers/updatePlayingField.ts
+++ b/rss-puzzle/src/helpers/updatePlayingField.ts
@@ -1,0 +1,73 @@
+import { getSound, initialState } from 'state/initialState';
+import CardWord from 'components/cardWord/cardWord';
+import createElement from './createElement';
+import { findElement } from './findElement';
+import transformButton from './transformButton';
+import changeDisabledButton from './changeDisabledButton';
+import wordsRandomOrder from './wordsRandomOrder';
+
+function resetSound(): void {
+  const sound = findElement('.sound');
+  if (!(sound instanceof HTMLAudioElement)) {
+    throw new Error('Element is not an audio');
+  }
+  sound.pause();
+  sound.currentTime = 0;
+  const button = findElement('.sound-button');
+  button.classList.remove('play');
+}
+
+function renderBlockWords(
+  result: HTMLElement | null,
+  source: HTMLElement | null
+): void {
+  if (initialState.currentSentence) {
+    const { textExample } = initialState.currentSentence;
+    const wordArray = textExample.split(' ');
+    initialState.changeGameStatus({ count: 0, limit: wordArray.length - 1 });
+
+    wordsRandomOrder(wordArray).forEach((word, position) => {
+      const card = new CardWord(word);
+      if (result) {
+        card.draw(result, 'result', position);
+      }
+      if (source) {
+        card.draw(source, 'source', position);
+      }
+    });
+  }
+}
+
+function updatePlayingField(isReset?: boolean): void {
+  const hintElement = findElement('.hint-content');
+  hintElement.textContent =
+    initialState.currentSentence?.textExampleTranslate || '';
+
+  const resultContainer = findElement('.results-container');
+  if (isReset) {
+    resultContainer.innerHTML = '';
+  }
+
+  const resultBlockId = initialState.currentSentence?.id;
+
+  const resultBlock = createElement('div', {
+    class: 'result-block',
+    'data-result_id': `${resultBlockId}`,
+  });
+
+  const sourceBlock = findElement('.source-block');
+  sourceBlock.innerHTML = '';
+
+  renderBlockWords(resultBlock, sourceBlock);
+  resultContainer.append(resultBlock);
+
+  resetSound();
+
+  getSound(initialState.currentSentence?.audioExample || '');
+
+  transformButton('check');
+  changeDisabledButton(true);
+  changeDisabledButton(false, '.complete-btn');
+}
+
+export { updatePlayingField };

--- a/rss-puzzle/src/state/initialState.ts
+++ b/rss-puzzle/src/state/initialState.ts
@@ -25,6 +25,7 @@ type StateApp = {
   chnageSoundVisible(): void;
   changeGameStatus(data: GameStatusType): void;
   updateCurrentSentence(): void;
+  updateCurrentRound(round: Round): void;
 };
 
 type LevelDataType = {
@@ -80,6 +81,11 @@ const initialState: StateApp = {
   changeGameStatus(data: GameStatusType): void {
     this.gameStatus = data;
   },
+  updateCurrentRound(round: Round): void {
+    this.currentRound = round;
+    const [sentence] = round.words;
+    this.currentSentence = sentence;
+  },
   updateCurrentSentence(): void {
     if (this.currentSentence && this.currentRound) {
       const { id } = this.currentSentence;
@@ -102,9 +108,9 @@ const initialState: StateApp = {
   },
 };
 
-async function getRounds(): Promise<void> {
+async function getRounds(level = 1): Promise<void> {
   await fetch(
-    'https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/data/wordCollectionLevel1.json'
+    `https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/data/wordCollectionLevel${level}.json`
   )
     .then((response) => response.json())
     .then((data: RoundsData) => {
@@ -114,7 +120,6 @@ async function getRounds(): Promise<void> {
 }
 
 async function getSound(audioExample: string): Promise<void> {
-  console.log(audioExample);
   const url = `https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/${audioExample}`;
   await fetch(url)
     .then((response) => response.blob())
@@ -123,7 +128,7 @@ async function getSound(audioExample: string): Promise<void> {
       initialState.currentUrlAudio = urlFile;
       const source = findElement('.source');
       if (!(source instanceof HTMLSourceElement)) {
-        throw new Error('ss');
+        throw new Error('source not HTMLSourceElement');
       }
       source.src = urlFile;
     })


### PR DESCRIPTION
## Pull Request -Style Change of Audio Icon During Pronunciation Playback ([feat: RSS-PZ-25](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-25.md))

### Overview

In this Pull Request implemented a feature that enables players to choose from six difficulty levels, with the number of game rounds based on the chosen level.

### Features Implemented

- [x]  add 'select' element for players to select from six difficulty levels.
- [x]  add 'select' element for players to choose from round.
- [x] add logic for update the playing field 

### Screenshots

![image](https://github.com/Oleg-Melnikow/code-format-lint/assets/14839880/ba70df14-cdbf-4ec2-a35f-20dcc4262b0b)


